### PR TITLE
Remove unnecessary manifest declarations from library

### DIFF
--- a/chronos/src/main/AndroidManifest.xml
+++ b/chronos/src/main/AndroidManifest.xml
@@ -1,10 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.redmadrobot.chronos">
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name">
-
-    </application>
-
 </manifest>

--- a/chronos/src/main/res/values/strings.xml
+++ b/chronos/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Chronos</string>
-</resources>


### PR DESCRIPTION
Library shouldn’t specify android:allowBackup value, as doing so can
cause conflicts with applications attempting to use the library that
may have this value set to false.

Also, no need for library to specify an application label, or even
declare an application in the manifest.

Finally, without using the label, there’s no need for strings.xml in
the library.
